### PR TITLE
fix(cli): fix TSX loader execution on Windows for schema generation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniter-js/cli",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "CLI for Igniter.js type-safe client generation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Fix: TSX Loader Compatibility on Windows for Schema Generation

This PR resolves a bug that prevented the correct execution of the generate schema command on Windows, specifically in the @igniter-js/cli package (introspector.ts). The main changes include:

Adjustment of Windows environment detection when invoking TSX via child_process, ensuring the command runs correctly across different operating systems.
Improved error handling and debug messages during dynamic router loading, making it easier to identify issues.
Ensures the TSX loader is used robustly, prioritizing developer experience and CLI stability.
These changes follow Igniter.js architectural principles, reinforcing modularity, clarity, and developer experience. I request review and approval for merge.